### PR TITLE
Customised last item in crumbs (issue #277)

### DIFF
--- a/src/Breadcrumbs.astro
+++ b/src/Breadcrumbs.astro
@@ -13,6 +13,7 @@ export interface BreadcrumbsProps {
   ellipsisAriaLabel?: string;
   truncated?: boolean;
   linkTextFormat?: "lower" | "capitalized" | "sentence";
+  lastText?: string;
   customBaseUrl?: string;
   excludeCurrentPage?: boolean;
 }
@@ -32,6 +33,7 @@ const {
   ellipsisAriaLabel = "Show hidden navigation",
   truncated = false,
   linkTextFormat,
+  lastText,
   customBaseUrl,
   excludeCurrentPage = false,
 } = Astro.props as BreadcrumbsProps;
@@ -49,6 +51,7 @@ const parts = generateCrumbs({
   linkTextFormat,
   customBaseUrl,
   excludeCurrentPage,
+  lastText,
 });
 
 const isLastElement = (index: number, array: any[]) =>

--- a/src/lib/generateCrumbs.ts
+++ b/src/lib/generateCrumbs.ts
@@ -9,6 +9,7 @@ type GenerateCrumbs = {
   linkTextFormat: BreadcrumbsProps["linkTextFormat"];
   customBaseUrl: BreadcrumbsProps["customBaseUrl"];
   excludeCurrentPage: BreadcrumbsProps["excludeCurrentPage"];
+  lastText: BreadcrumbsProps["lastText"];
 };
 
 export const generateCrumbs = ({
@@ -19,6 +20,7 @@ export const generateCrumbs = ({
   linkTextFormat,
   customBaseUrl,
   excludeCurrentPage,
+  lastText,
 }: GenerateCrumbs) => {
   /**
    * If crumbs are passed, use them.
@@ -111,6 +113,12 @@ export const generateCrumbs = ({
    */
   if (excludeCurrentPage) {
     parts.pop();
+  }
+  /**
+   * If lastText has value, replace the last item's text with it.
+   */
+  if (lastText) {
+    parts[parts.length - 1].text = lastText;
   }
 
   return parts;

--- a/tests/unit/generateCrumbs.test.ts
+++ b/tests/unit/generateCrumbs.test.ts
@@ -317,3 +317,23 @@ test("generateCrumbs - don't exclude current page", () => {
     { text: "Path 3", href: "/path-1/path-2/path-3" },
   ]);
 });
+
+test("generateCrumbs - replace last item text with custom text", () => {
+  const result = generateCrumbs({
+    crumbs: [],
+    paths: ["path-1", "path-2", "path-3"],
+    indexText: "Home",
+    hasTrailingSlash: false,
+    linkTextFormat: "sentence",
+    customBaseUrl: undefined,
+    excludeCurrentPage: false,
+    lastText: "Last Path",
+  });
+
+  expect(result).toEqual([
+    { text: "Home", href: "/" },
+    { text: "Path 1", href: "/path-1" },
+    { text: "Path 2", href: "/path-1/path-2" },
+    { text: "Last Path", href: "/path-1/path-2/path-3" },
+  ]);
+});


### PR DESCRIPTION
Example URL: 
<img width="418" alt="Screenshot 2024-06-11 at 10 28 26 PM" src="https://github.com/felix-berlin/astro-breadcrumbs/assets/55761841/4a5fef21-b92e-4281-8329-2636c1ff1079">

Current Breadcrumb Sequence:
<img width="420" alt="Screenshot 2024-06-11 at 10 30 23 PM" src="https://github.com/felix-berlin/astro-breadcrumbs/assets/55761841/b0b9eff7-0853-4eb8-9674-63716734961c">


Current Code:
<img width="408" alt="Screenshot 2024-06-11 at 10 32 02 PM" src="https://github.com/felix-berlin/astro-breadcrumbs/assets/55761841/d4d7a4cc-d773-4eab-a24d-255245a58cf1">

<hr>

# With this Change

New Code Looks Like:
<img width="638" alt="Screenshot 2024-06-11 at 10 34 05 PM" src="https://github.com/felix-berlin/astro-breadcrumbs/assets/55761841/8c11f832-2e25-4cdb-99f0-0f950fcd41cc">

New Breadcrumb Sequence:
<img width="400" alt="Screenshot 2024-06-11 at 10 35 01 PM" src="https://github.com/felix-berlin/astro-breadcrumbs/assets/55761841/291e6a52-4326-4474-828d-0f1b73504b96">


