### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/felix-berlin/astro-breadcrumbs/security/code-scanning/1](https://github.com/felix-berlin/astro-breadcrumbs/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, the `contents: read` permission is sufficient for most operations, as the workflow primarily involves checking out the repository, setting up dependencies, and running a release script. If additional permissions are required for specific steps, they can be added to the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
