### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,7 @@
 name: Unit tests
+permissions:
+  contents: read
+  statuses: write
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/felix-berlin/astro-breadcrumbs/security/code-scanning/2](https://github.com/felix-berlin/astro-breadcrumbs/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, the following permissions are needed:
- `contents: read` to allow the workflow to access the repository's contents (e.g., for checking out the code).
- `statuses: write` to allow the workflow to update commit statuses (e.g., marking the test results).

This ensures that the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
