### PR TITLE
Strip file extensions from paths before generating hrefs

### DIFF
--- a/src/lib/generateCrumbs.ts
+++ b/src/lib/generateCrumbs.ts
@@ -51,27 +51,29 @@ export const generateCrumbs = ({
     paths.unshift(customBaseUrl);
   }
   /**
+   * Strip out any file extensions (e.g. ".html", ".js") from each path segment
+   * up front, so neither the visible text nor the generated href leaks them.
+   */
+  const strippedPaths = paths.map((text) => {
+    const matches = text.match(/^(.+?)(\.[a-z0-9]+)?\/?$/i);
+    return matches?.[2] ? matches[1] : text;
+  });
+
+  /**
    * Loop through the paths and create a breadcrumb item for each.
    */
-  paths.forEach((text: string, index: number) => {
+  strippedPaths.forEach((text: string, index: number) => {
     /**
-     * generateHref will create the href out of the paths array.
+     * generateHref will create the href out of the stripped paths array.
      * Example: ["path1", "path2"] => /path1/path2
      */
-    const generateHref = `/${paths.slice(0, index + 1).join("/")}`;
+    const generateHref = `/${strippedPaths.slice(0, index + 1).join("/")}`;
 
     const addTrailingSlash = hasTrailingSlash
       ? `${generateHref}/`
       : generateHref;
 
     const finalHref = addTrailingSlash;
-
-    // strip out any file extensions
-    const matches = text.match(/^(.+?)(\.[a-z0-9]+)?\/?$/i);
-
-    if (matches?.[2]) {
-      text = matches[1];
-    }
 
     parts.push({
       text: formatLinkText(text, linkTextFormat),

--- a/tests/unit/generateCrumbs.test.ts
+++ b/tests/unit/generateCrumbs.test.ts
@@ -98,13 +98,13 @@ test("generateCrumbs - paths with file extensions", () => {
   // Check if the second crumb is correct
   expect(result[1]).toEqual({
     text: "Path1",
-    href: "/path1.html/",
+    href: "/path1/",
   });
 
   // Check if the third crumb is correct
   expect(result[2]).toEqual({
     text: "Path2",
-    href: "/path1.html/path2.js/",
+    href: "/path1/path2/",
   });
 });
 


### PR DESCRIPTION
## Summary

Refactored the file extension stripping logic in `generateCrumbs` to process all paths upfront rather than individually during breadcrumb generation. This ensures file extensions are removed from both the visible text and the generated hrefs consistently.

## Key Changes

- **Moved extension stripping logic earlier**: Created a `strippedPaths` array that removes file extensions from all path segments before the breadcrumb loop, rather than stripping them individually within the loop.
- **Updated href generation**: Changed `generateHref` to use `strippedPaths` instead of the original `paths` array, ensuring hrefs don't contain file extensions.
- **Updated test expectations**: Fixed test assertions in `generateCrumbs.test.ts` to reflect that hrefs should no longer contain file extensions (e.g., `/path1.html/path2.js/` → `/path1/path2/`).

## Implementation Details

The extension stripping regex (`/^(.+?)(\.[a-z0-9]+)?\/?$/i`) is applied once to each path segment via `map()`, capturing the filename without extension in group 1. This approach:
- Reduces redundant regex matching
- Makes the intent clearer by separating concerns (strip extensions first, then generate breadcrumbs)
- Ensures consistency between visible text and href generation

https://claude.ai/code/session_015p7vAaQAFmV8UAqbkCRB96